### PR TITLE
update bg/zh tables

### DIFF
--- a/table/bg_sample_list.txt
+++ b/table/bg_sample_list.txt
@@ -3,74 +3,74 @@
 #
 # 4 fermion background
 # 
-zz_h0utut       ,      up up up up                    ,       83.09  ,       419604  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_h.e0.p0.whizard195/                        ,  CEPC_V4  ,  zz_h0utut.e0.p0
-zz_h0dtdt       ,      down down down down            ,      226.20  ,      1142310  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_h.e0.p0.whizard195/                        ,  CEPC_V4  ,  zz_h0dtdt.e0.p0
-zz_h0uu_notd    ,      uq uq (sq/bq) (sq/bq)          ,       95.65  ,       483032  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_h.e0.p0.whizard195/                        ,  CEPC_V4  ,  zz_h0uu_notd.e0.p0
-zz_h0cc_nots    ,      cq cq  (dq/bq) (dq/bq)         ,       96.04  ,       485002  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_h.e0.p0.whizard195/                        ,  CEPC_V4  ,  zz_h0cc_nots.e0.p0
+zz_h0utut       ,      up up up up                    ,       85.68 ,       432684 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_h.e0.p0.whizard195/                        ,  CEPC_V4  ,  zz_h0utut.e0.p0
+zz_h0dtdt       ,      down down down down            ,      233.46 ,      1178973 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_h.e0.p0.whizard195/                        ,  CEPC_V4  ,  zz_h0dtdt.e0.p0
+zz_h0uu_notd    ,      uq uq (sq/bq) (sq/bq)          ,       98.56 ,       497728 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_h.e0.p0.whizard195/                        ,  CEPC_V4  ,  zz_h0uu_notd.e0.p0
+zz_h0cc_nots    ,      cq cq  (dq/bq) (dq/bq)         ,       98.97 ,       499799 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_h.e0.p0.whizard195/                        ,  CEPC_V4  ,  zz_h0cc_nots.e0.p0
 #
-zz_sl0nu_up     ,      nu_mu/tau nu_mu/tau up up      ,       81.72  ,       412686  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_sl.e0.p0.whizard195/                       ,  CEPC_V4  ,  zz_sl0nu_up.e0.p0
-zz_sl0nu_down   ,      nu_mu/tau nu_mu/tau down down  ,      134.86  ,       681043  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_sl.e0.p0.whizard195/                       ,  CEPC_V4  ,  zz_sl0nu_down.e0.p0
-zz_sl0mu_up     ,      mu mu up up                    ,       82.38  ,       416019  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_sl.e0.p0.whizard195/                       ,  CEPC_V4  ,  zz_sl0mu_up.e0.p0
-zz_sl0mu_down   ,      mu mu down down                ,      127.96  ,       646198  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_sl.e0.p0.whizard195/                       ,  CEPC_V4  ,  zz_sl0mu_down.e0.p0
-zz_sl0tau_up    ,      tau tau up up                  ,       39.78  ,       200889  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_sl.e0.p0.whizard195/                       ,  CEPC_V4  ,  zz_sl0tau_up.e0.p0
-zz_sl0tau_down  ,      tau tau down down              ,       64.30  ,       324715  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_sl.e0.p0.whizard195/                       ,  CEPC_V4  ,  zz_sl0tau_down.e0.p0
+zz_sl0nu_up     ,      nu_mu/tau nu_mu/tau up up      ,       84.38 ,       426119 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_sl.e0.p0.whizard195/                       ,  CEPC_V4  ,  zz_sl0nu_up.e0.p0
+zz_sl0nu_down   ,      nu_mu/tau nu_mu/tau down down  ,      139.71 ,       705536 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_sl.e0.p0.whizard195/                       ,  CEPC_V4  ,  zz_sl0nu_down.e0.p0
+zz_sl0mu_up     ,      mu mu up up                    ,       87.39 ,       441320 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_sl.e0.p0.whizard195/                       ,  CEPC_V4  ,  zz_sl0mu_up.e0.p0
+zz_sl0mu_down   ,      mu mu down down                ,      136.14 ,       687507 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_sl.e0.p0.whizard195/                       ,  CEPC_V4  ,  zz_sl0mu_down.e0.p0
+zz_sl0tau_up    ,      tau tau up up                  ,       41.56 ,       209878 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_sl.e0.p0.whizard195/                       ,  CEPC_V4  ,  zz_sl0tau_up.e0.p0
+zz_sl0tau_down  ,      tau tau down down              ,       67.31 ,       339916 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_sl.e0.p0.whizard195/                       ,  CEPC_V4  ,  zz_sl0tau_down.e0.p0
 #
-zz_l04tau       ,      tau tau tau tau                ,        4.38  ,        22119  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_l.e0.p0.whizard195/                        ,  CEPC_V4  ,  zz_l04tau.e0.p0
-zz_l04mu        ,      mu mu mu mu                    ,       14.57  ,        73578  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_l.e0.p0.whizard195/                        ,  CEPC_V4  ,  zz_l04mu.e0.p0
-zz_l0taumu      ,      tau tau mu mu                  ,       17.54  ,        88577  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_l.e0.p0.whizard195/                        ,  CEPC_V4  ,  zz_l0taumu.e0.p0
-zz_l0mumu       ,      nu_tau nu_tau mu mu            ,       18.17  ,        91758  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_l.e0.p0.whizard195/                        ,  CEPC_V4  ,  zz_l0mumu.e0.p0
-zz_l0tautau     ,      nu_mu nu_mu tau tau            ,        9.20  ,        46460  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_l.e0.p0.whizard195/                        ,  CEPC_V4  ,  zz_l0tautau.e0.p0
+zz_l04tau       ,      tau tau tau tau                ,        4.61 ,        23281 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_l.e0.p0.whizard195/                        ,  CEPC_V4  ,  zz_l04tau.e0.p0
+zz_l04mu        ,      mu mu mu mu                    ,       15.56 ,        78578 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_l.e0.p0.whizard195/                        ,  CEPC_V4  ,  zz_l04mu.e0.p0
+zz_l0taumu      ,      tau tau mu mu                  ,       18.56 ,        93728 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_l.e0.p0.whizard195/                        ,  CEPC_V4  ,  zz_l0taumu.e0.p0
+zz_l0mumu       ,      nu_tau nu_tau mu mu            ,       19.38 ,        97869 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_l.e0.p0.whizard195/                        ,  CEPC_V4  ,  zz_l0mumu.e0.p0
+zz_l0tautau     ,      nu_mu nu_mu tau tau            ,        9.61 ,        48531 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzz_l.e0.p0.whizard195/                        ,  CEPC_V4  ,  zz_l0tautau.e0.p0
 #
-#ww_h0cuxx       ,      uq cq down down                ,     3395.48  ,     17147189  ,          not_generated_yet                                                                                ,           ,
-#ww_h0uubd       ,      uq uq dq bq                    ,        0.05  ,          252  ,          not_generated_yet                                                                                ,           ,
-#ww_h0uusd       ,      uq uq sq bq                    ,      165.94  ,       837997  ,          not_generated_yet                                                                                ,           ,
-#ww_h0ccbs       ,      cq cq sq bq                    ,        5.74  ,        28987  ,          not_generated_yet                                                                                ,           ,
-#ww_h0ccds       ,      cq cq sq dq                    ,      165.57  ,       836128  ,          not_generated_yet                                                                                ,           ,
-ww_h0cuxx       ,      uq cq down down                ,     3395.48  ,     17147189  ,          /cefs/dirac/user/b/byzhang/ww_h/cuxx_01/rec/                                                     ,       V1  ,  ww_h0cuxx.e0.p0
-ww_h0uubd       ,      uq uq dq bq                    ,        0.05  ,          252  ,          /cefs/dirac/user/b/byzhang/RecData/ww_h/uubd/                                                    ,       V1  ,  Pww_h0uubd.e0.p0
-ww_h0uusd       ,      uq uq sq bq                    ,      165.94  ,       837997  ,          /cefs/dirac/user/b/byzhang/RecData/ww_h/uusd/                                                    ,       V1  ,  E250.Pww_h0uusd.e0.p0
-ww_h0ccbs       ,      cq cq sq bq                    ,        5.74  ,        28987  ,          /cefs/dirac/user/b/byzhang/RecData/ww_h/ccbs/                                                    ,       V1  ,  Pww_h0ccbs.e0.p0
-ww_h0ccds       ,      cq cq sq dq                    ,      165.57  ,       836128  ,          /cefs/dirac/user/b/byzhang/RecData/ww_h/ccds/                                                    ,       V1  ,  E250.Pww_h0ccds.e0.p0
+ww_h0cuxx       ,      uq cq down down                ,     3478.89 ,     17568395 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pww_h.e0.p0.whizard195/                        ,  CEPC_V4  ,  ww_h0cuxx.e0.p0
+ww_h0uubd       ,      uq uq dq bq                    ,        0.05 ,          253 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pww_h.e0.p0.whizard195/                        ,  CEPC_V4  ,  ww_h0uubd.e0.p0
+ww_h0uusd       ,      uq uq sq bq                    ,      170.45 ,       860773 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pww_h.e0.p0.whizard195/                        ,  CEPC_V4  ,  ww_h0uusd.e0.p0
+ww_h0ccbs       ,      cq cq sq bq                    ,        5.89 ,        29745 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pww_h.e0.p0.whizard195/                        ,  CEPC_V4  ,  ww_h0ccbs.e0.p0
+ww_h0ccds       ,      cq cq sq dq                    ,      170.18 ,       859409 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pww_h.e0.p0.whizard195/                        ,  CEPC_V4  ,  ww_h0ccds.e0.p0
+#ww_h0cuxx       ,      uq cq down down                ,     3478.89 ,     17568395 ,          /cefs/dirac/user/b/byzhang/ww_h/cuxx_01/rec/                                                     ,       V1  ,  ww_h0cuxx.e0.p0
+#ww_h0uubd       ,      uq uq dq bq                    ,        0.05 ,          253 ,          /cefs/dirac/user/b/byzhang/RecData/ww_h/uubd/                                                    ,       V1  ,  Pww_h0uubd.e0.p0
+#ww_h0uusd       ,      uq uq sq bq                    ,      170.45 ,       860773 ,          /cefs/dirac/user/b/byzhang/RecData/ww_h/uusd/                                                    ,       V1  ,  E250.Pww_h0uusd.e0.p0
+#ww_h0ccbs       ,      cq cq sq bq                    ,        5.89 ,        29745 ,          /cefs/dirac/user/b/byzhang/RecData/ww_h/ccbs/                                                    ,       V1  ,  Pww_h0ccbs.e0.p0
+#ww_h0ccds       ,      cq cq sq dq                    ,      170.18 ,       859409 ,          /cefs/dirac/user/b/byzhang/RecData/ww_h/ccds/                                                    ,       V1  ,  E250.Pww_h0ccds.e0.p0
 #
-ww_sl0muq       ,      mu nu_mu up down               ,     2358.69  ,     11911394  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pww_sl.e0.p0.whizard195/                       ,  CEPC_V4  ,  ww_sl0muq.e0.p0
-ww_sl0tauq      ,      tau tau_nu up down             ,     2351.98  ,     11877519  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pww_sl.e0.p0.whizard195/                       ,  CEPC_V4  ,  ww_sl0tauq.e0.p0
-ww_l0ll         ,      mu tau nu_mu nu_tau            ,      392.96  ,      1984448  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pww_l.e0.p0.whizard195/                        ,  CEPC_V4  ,  ww_l0ll.e0.p0
+ww_sl0muq       ,      mu nu_mu up down               ,     2423.43 ,     12238322 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pww_sl.e0.p0.whizard195/                       ,  CEPC_V4  ,  ww_sl0muq.e0.p0
+ww_sl0tauq      ,      tau tau_nu up down             ,     2423.56 ,     12238978 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pww_sl.e0.p0.whizard195/                       ,  CEPC_V4  ,  ww_sl0tauq.e0.p0
+ww_l0ll         ,      mu tau nu_mu nu_tau            ,      403.66 ,      2038483 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pww_l.e0.p0.whizard195/                        ,  CEPC_V4  ,  ww_l0ll.e0.p0
 #
-#zzorww_h0udud   ,      uq uq dq dq                    ,     1570.40  ,     7930514  ,          not_generated_yet                                                                                ,       
-#zzorww_h0cscs   ,      cq cq sq sq                    ,     1568.94  ,     7923141  ,          not_generated_yet                                                                                ,    
-zzorww_h0udud   ,      uq uq dq dq                    ,     1570.40  ,      7930514  ,          /cefs/dirac/user/b/byzhang/zzorww_h/sim_01/rec/                                                  ,       V1  ,  zzorww_h0udud.e0.p0
-zzorww_h0cscs   ,      cq cq sq sq                    ,     1568.94  ,      7923141  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzzorww_h.e0.p0.whizard195/                    ,  CEPC_V4  ,  zzorww_h0cscs.e0.p0
-zzorww_l0mumu   ,      mu mu nu_mu nu_mu              ,      214.81  ,      1084790  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzzorww_l.e0.p0.whizard195/                    ,  CEPC_V4  ,  zzorww_l0mumu.e0.p0
-zzorww_l0tautau ,      tau tau nu_tau nu_tau          ,      205.84  ,      1039492  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzzorww_l.e0.p0.whizard195/                    ,  CEPC_V4  ,  zzorww_l0tautau.e0.p0
+#zzorww_h0udud   ,      uq uq dq dq                    ,     1610.32 ,      8132116 ,          /cefs/dirac/user/b/byzhang/zzorww_h/sim_01/rec/                                                  ,       V1  ,  zzorww_h0udud.e0.p0
+zzorww_h0udud   ,      uq uq dq dq                    ,     1610.32 ,      8132116 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzzorww_h.e0.p0.whizard195/                    ,  CEPC_V4  ,  zzorww_h0udud.e0.p0
+zzorww_h0cscs   ,      cq cq sq sq                    ,     1607.55 ,      8118128 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzzorww_h.e0.p0.whizard195/                    ,  CEPC_V4  ,  zzorww_h0cscs.e0.p0
+zzorww_l0mumu   ,      mu mu nu_mu nu_mu              ,      221.10 ,      1116555 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzzorww_l.e0.p0.whizard195/                    ,  CEPC_V4  ,  zzorww_l0mumu.e0.p0
+zzorww_l0tautau ,      tau tau nu_tau nu_tau          ,      211.18 ,      1066459 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pzzorww_l.e0.p0.whizard195/                    ,  CEPC_V4  ,  zzorww_l0tautau.e0.p0
 #
-sze_l0tau       ,      e e tau tau                    ,      150.14  ,       758207  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psze_l.e0.p0.whizard195/                       ,  CEPC_V4  ,  sze_l0tau.e0.p0
-sze_l0mu        ,      e e mu mu                      ,      852.18  ,      4303527  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psze_l.e0.p0.whizard195/                       ,  CEPC_V4  ,  sze_l0mu.e0.p0
-sze_l0nunu      ,      e e nu_mu/tau nu_mu/tau        ,       29.62  ,       149581  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psze_l.e0.p0.whizard195/                       ,  CEPC_V4  ,  sze_l0nunu.e0.p0
+sze_l0tau       ,      e e tau tau                    ,      147.28 ,       743764 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psze_l.e0.p0.whizard195/                       ,  CEPC_V4  ,  sze_l0tau.e0.p0
+sze_l0mu        ,      e e mu mu                      ,      845.81 ,      4271341 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psze_l.e0.p0.whizard195/                       ,  CEPC_V4  ,  sze_l0mu.e0.p0
+sze_l0nunu      ,      e e nu_mu/tau nu_mu/tau        ,       28.94 ,       146147 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psze_l.e0.p0.whizard195/                       ,  CEPC_V4  ,  sze_l0nunu.e0.p0
 #
-sze_sl0uu       ,      e e up up                      ,      195.86  ,       989093  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psze_sl.e0.p0.whizard195/                      ,  CEPC_V4  ,  sze_sl0uu.e0.p0
-sze_sl0dd       ,      e e down down                  ,      128.72  ,       650036  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psze_sl.e0.p0.whizard195/                      ,  CEPC_V4  ,  sze_sl0dd.e0.p0
+sze_sl0uu       ,      e e up up                      ,      190.21 ,       960561 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psze_sl.e0.p0.whizard195/                      ,  CEPC_V4  ,  sze_sl0uu.e0.p0
+sze_sl0dd       ,      e e down down                  ,      125.83 ,       635442 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psze_sl.e0.p0.whizard195/                      ,  CEPC_V4  ,  sze_sl0dd.e0.p0
 #
-sznu_l0mumu     ,      nu_e nu_e mu mu                ,       43.33  ,       218816  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psznu_l.e0.p0.whizard195/                      ,  CEPC_V4  ,  sznu_l0mumu.e0.p0
-sznu_l0tautau   ,      nu_e nu_e tau tau              ,       14.57  ,        73578  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psznu_l.e0.p0.whizard195/                      ,  CEPC_V4  ,  sznu_l0tautau.e0.p0
+sznu_l0mumu     ,      nu_e nu_e mu mu                ,       43.42 ,       219271 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psznu_l.e0.p0.whizard195/                      ,  CEPC_V4  ,  sznu_l0mumu.e0.p0
+sznu_l0tautau   ,      nu_e nu_e tau tau              ,       14.57 ,        73579 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psznu_l.e0.p0.whizard195/                      ,  CEPC_V4  ,  sznu_l0tautau.e0.p0
 #
-sznu_sl0nu_up   ,      nu_e nu_e up up                ,       56.09  ,       283254  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psznu_sl.e0.p0.whizard195/                     ,  CEPC_V4  ,  sznu_sl0nu_up.e0.p0
-sznu_sl0nu_down ,      nu_e nu_e down down            ,       91.28  ,       460964  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psznu_sl.e0.p0.whizard195/                     ,  CEPC_V4  ,  sznu_sl0nu_down.e0.p0
+sznu_sl0nu_up   ,      nu_e nu_e up up                ,       55.59 ,       280730 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psznu_sl.e0.p0.whizard195/                     ,  CEPC_V4  ,  sznu_sl0nu_up.e0.p0
+sznu_sl0nu_down ,      nu_e nu_e down down            ,       90.03 ,       454652 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psznu_sl.e0.p0.whizard195/                     ,  CEPC_V4  ,  sznu_sl0nu_down.e0.p0
 #
-sw_l0mu         ,      e nu_e mu nu_mu                ,      429.20  ,      2167446  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psw_l.e0.p0.whizard195/                        ,  CEPC_V4  ,  sw_l0mu.e0.p0
-sw_l0tau        ,      e nu_e tau nu_tau              ,      429.42  ,      2168556  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psw_l.e0.p0.whizard195/                        ,  CEPC_V4  ,  sw_l0tau.e0.p0
+sw_l0mu         ,      e nu_e mu nu_mu                ,      436.70 ,      2205335 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psw_l.e0.p0.whizard195/                        ,  CEPC_V4  ,  sw_l0mu.e0.p0
+sw_l0tau        ,      e nu_e tau nu_tau              ,      435.93 ,      2201447 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psw_l.e0.p0.whizard195/                        ,  CEPC_V4  ,  sw_l0tau.e0.p0
 #
-sw_sl0qq        ,      e nu_e up down                 ,      2579.31 ,     13025535  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psw_sl.e0.p0.whizard195/                       ,  CEPC_V4  ,  sw_sl0qq.e0.p0
+sw_sl0qq        ,      e nu_e up down                 ,     2612.62 ,     13193731 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Psw_sl.e0.p0.whizard195/                       ,  CEPC_V4  ,  sw_sl0qq.e0.p0
 #
-szeorsw_l0l     ,      e e nu_e nu_e                  ,       249.34 ,      1259167  ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pszeorsw_l.e0.p0.whizard195/                   ,  CEPC_V4  ,  szeorsw_l0l.e0.p0
+szeorsw_l0l     ,      e e nu_e nu_e                  ,      249.48 ,      1259874 ,          /cefs/data/DstData/CEPC240/CEPC_v4/4fermions/E240.Pszeorsw_l.e0.p0.whizard195/                   ,  CEPC_V4  ,  szeorsw_l0l.e0.p0
 #
 # 2 fermion background
 # 
-#uu              ,  u u                                ,     9995.35  ,     50476527  ,                                                                                                           ,           ,  
-#dd              ,  d d                                ,     9808.71  ,     49533965  ,                                                                                                           ,           ,
-#cc              ,  c c                                ,     9974.20  ,     50369725  ,                                                                                                           ,           ,
-#ss              ,  s s                                ,     9805.39  ,     49517234  ,                                                                                                           ,           ,
-#bb              ,  b b                                ,     9803.04  ,     49505372  ,                                                                                                           ,           ,
-qq              ,  q q                                ,    49561.30  ,    250284565  ,          /cefs/data/DstData/CEPC240/CEPC_v4/2fermions/E240.Pqq.e0.p0.whizard195/                          ,  CEPC_V4  ,  qq.e0.p0
-e2e2            ,  mu mu                              ,     4967.58  ,     25086253  ,          /cefs/data/RecData/CEPC250/CEPC_v1/2fermions/E250.Pe2e2.e0.p0.whizard195/e2e2/                   ,       V1  ,  E250.Pe2e2.e0.p0
-e3e3            ,  tau tau                            ,     4374.94  ,     22093447  ,          /cefs/data/RecData/CEPC250/CEPC_v1/2fermions/E250.Pe3e3.e0.p0.whizard195/                        ,       V1  ,  E250.Pe3e3.e0.p0
-e1e1            ,  e e gamma                          ,    24992.21  ,    126210660  ,          /cefs/data/RecData/CEPC250/CEPC_v1/2fermions/bhabha/                                             ,       V1  ,  e1e1
+qq              ,      q q                            ,    54106.86 ,    273239643 ,          /cefs/data/DstData/CEPC240/CEPC_v4/2fermions/E240.Pqq.e0.p0.whizard195/                          ,  CEPC_V4  ,  qq.e0.p0
+e2e2            ,      mu mu                          ,     5332.71 ,     26930186 ,          /cefs/data/DstData/CEPC240/CEPC_v4/2fermions/E240.Pe2e2.e0.p0.whizard195/                        ,  CEPC_V4  ,  e2e2.e0.p0
+e3e3            ,      tau tau                        ,     4752.89 ,     24002095 ,          /cefs/data/DstData/CEPC240/CEPC_v4/2fermions/E240.Pe3e3.e0.p0.whizard195/                        ,  CEPC_V4  ,  e3e3.e0.p0
+e1e1            ,      e e gamma                      ,    24770.90 ,    125093045 ,          /cefs/data/DstData/CEPC240/CEPC_v4/2fermions/E240.Pbhabha.e0.p0.whizard195/                      ,  CEPC_V4  ,  bhabha.e0.p0
+#e2e2            ,      mu mu                          ,     5332.71 ,     26930186 ,          /cefs/data/RecData/CEPC250/CEPC_v1/2fermions/E250.Pe2e2.e0.p0.whizard195/e2e2/                   ,       V1  ,  E250.Pe2e2.e0.p0
+#e3e3            ,      tau tau                        ,     4752.89 ,     24002095 ,          /cefs/data/RecData/CEPC250/CEPC_v1/2fermions/E250.Pe3e3.e0.p0.whizard195/                        ,       V1  ,  E250.Pe3e3.e0.p0
+#e1e1            ,      e e gamma                      ,    24770.90 ,    125093045 ,          /cefs/data/RecData/CEPC250/CEPC_v1/2fermions/bhabha/                                             ,       V1  ,  e1e1
+n1n1            ,     nu_e nu_e                       ,    45390.79 ,    229223490 ,          /cefs/data/DstData/CEPC240/CEPC_v4/2fermions/E240.Pn1n1.e0.p0.whizard195/                        ,  CEPC_V4  ,  n1n1.e0.p0
+n2n2            ,     nu_mu nu_mu                     ,     4416.30 ,     22302315 ,          /cefs/data/DstData/CEPC240/CEPC_v4/2fermions/E240.Pn2n2.e0.p0.whizard195/                        ,  CEPC_V4  ,  n2n2.e0.p0
+n3n3            ,     nu_tau nu_tau                   ,     4410.26 ,     22271813 ,          /cefs/data/DstData/CEPC240/CEPC_v4/2fermions/E240.Pn3n3.e0.p0.whizard195/                        ,  CEPC_V4  ,  n3n3.e0.p0

--- a/table/zh_sample_list.txt
+++ b/table/zh_sample_list.txt
@@ -4,9 +4,9 @@
 # ZH signals 
 # 
 # newly generated
-#e1e1h_X    ,      e e     higgs  ,          7.04  ,       35552  ,          /afs/ihep.ac.cn/users/k/kiuchi/h2zz/TestFullSim/reconstruction/output/e1e1h_X/      ,  CEPC_V4  ,  e1e1h_X.e0.p0
-#e2e2h_X    ,      mu mu   higgs  ,          6.77  ,       34189  ,          /afs/ihep.ac.cn/users/k/kiuchi/h2zz/TestFullSim/reconstruction/output/e2e2h_X/      ,  CEPC_V4  ,  e2e2h_X.e0.p0
-#e3e3h_X    ,      tau tau higgs  ,          6.75  ,       34088  ,          /afs/ihep.ac.cn/users/k/kiuchi/h2zz/TestFullSim/reconstruction/output/e3e3h_X/      ,  CEPC_V4  ,  e3e3h_X.e0.p0
+e1e1h_X    ,      e e     higgs  ,          7.04  ,       35552  ,          /afs/ihep.ac.cn/users/k/kiuchi/h2zz/TestFullSim/reconstruction/output/e1e1h_X/      ,  CEPC_V4  ,  e1e1h_X.e0.p0
+e2e2h_X    ,      mu mu   higgs  ,          6.77  ,       34189  ,          /afs/ihep.ac.cn/users/k/kiuchi/h2zz/TestFullSim/reconstruction/output/e2e2h_X/      ,  CEPC_V4  ,  e2e2h_X.e0.p0
+e3e3h_X    ,      tau tau higgs  ,          6.75  ,       34088  ,          /afs/ihep.ac.cn/users/k/kiuchi/h2zz/TestFullSim/reconstruction/output/e3e3h_X/      ,  CEPC_V4  ,  e3e3h_X.e0.p0
 nnh_X      ,      nu nu   higgs  ,         46.29  ,      233765  ,          /afs/ihep.ac.cn/users/k/kiuchi/h2zz/TestFullSim/reconstruction/output/nnh_X/        ,  CEPC_V4  ,  nnh_X.e0.p0
 qqh_X      ,      q q     higgs  ,        131.81  ,      665641  ,          /afs/ihep.ac.cn/users/k/kiuchi/h2zz/TestFullSim/reconstruction/output/qqh_X/        ,  CEPC_V4  ,  qqh_X.e0.p0
 #


### PR DESCRIPTION
Update bg/zh tables:

1. bg table
-- Cross Section were taken from 250GeV  ==> Modify them to that for 240 GeV. 
-- Some of channels are switched to newly generated ones for CEPC_v4 

2. zh table
-- Some of lines were commented out for test purpose in previous upload , , ,  ==> modify to the original one.  