### PR TITLE
modify the fitting part for llhzz

### DIFF
--- a/python/plt_bg.py
+++ b/python/plt_bg.py
@@ -105,12 +105,20 @@ def draw_signal_bg(pic, x1, x2, title, combine_opt):
     for i in range(3):
         exec('max%s = b%s.GetMaximum()'%(i,i))
 
-    max = max0
+    max_signal = s.GetMaximum()
+    max = max_signal
+
+    if max0 > max:
+        max = max0
+
     if max1 > max:
         max = max1
     
     if max2 > max:
         max = max2
+
+
+    ROOT.gStyle.SetOptStat(000)
 
 #    ROOT.gPad.SetLogy(1)
 #    b0.SetMinimum(0.1)

--- a/python/plt_info.py
+++ b/python/plt_info.py
@@ -133,7 +133,10 @@ def main():
                                 exec ("ff%s += cut%s"%(i+1,i+1))
 
     print('\n')
-    print("%-25s%-15s%-15s%-15s%-15s"%('cut','llhzz','zh','2f','4f'))
+    if (combine_opt==1):
+        print("%-25s%-15s%-15s%-15s%-15s"%('cut','llhzz','zh','2f','4f'))
+    if (combine_opt==2):
+        print("%-25s%-15s%-15s%-15s%-15s"%('cut','nnhzz','zh','2f','4f'))
     print("%-25s%-15s%-15s%-15s%-15s"%('Raw events',int(s_raw),int(z_raw),int(f_raw),int(ff_raw)))
     print("%-25s%-15s%-15s%-15s%-15s"%('Pre-selection',int(s1),int(z1),int(f1),int(ff1)))
     print("%-25s%-15s%-15s%-15s%-15s"%('Signal or not',int(s2),int(z2),int(f2),int(ff2)))

--- a/python/save_root.py
+++ b/python/save_root.py
@@ -63,13 +63,15 @@ def main():
                     s = (event_exp / event_ana)
 
                     tep=sample.Get('hevtflw_sel')
-                    if tep.GetBinContent(11) != 0:
 
-                        if (combine_opt==1):
+                    if (combine_opt==1):
+                        if tep.GetBinContent(11) != 0:
                             b_out = './root/channel_ll/bkg_%s.root'%dname
-                        if (combine_opt==2):
+                            save_root(b_in, b_out, s, combine_opt)
+                    if (combine_opt==2):
+                        if tep.GetBinContent(16) != 0:
                             b_out = './root/channel_nn/bkg_%s.root'%dname
-                        save_root(b_in, b_out, s, combine_opt)
+                            save_root(b_in, b_out, s, combine_opt)
 
 def save_root(f_in, f_out, s, combine_opt):
 

--- a/submit.sh
+++ b/submit.sh
@@ -546,11 +546,11 @@ case $option in
 	   ;; 
 			
     1.4.4) echo  "Save results..."
-	   rm -rf ./root/llhzz
-	   mkdir -p   ./root/llhzz/merge
-	   python ./python/save_root.py  ./table/bg_2f.txt  ./table/bg_4f.txt  ./table/zh_sample_list.txt ${llhzz}
+	   rm -rf ./root/channel_ll
+	   mkdir -p   ./root/channel_ll/merge
+	   python ./python/save_root.py  ${llhzz} ./table/bg_2f.txt  ./table/bg_4f.txt  ./table/zh_sample_list.txt 
 
-	   cd ./root/llhzz
+	   cd ./root/channel_ll
 
 	   if [ ${channel_opt_ll} = 1 ]; then
 		cp sig.root ./merge/mzvj_sig.root
@@ -560,7 +560,7 @@ case $option in
 		hadd ./merge/mzvj_az.root bkg_e2e2h_az.root bkg_e3e3h_az.root
 		hadd ./merge/mzvj_sm.root bkg_zz_l0taumu.root bkg_zz_l04tau.root bkg_zz_sl0tau_up.root
 		cd ../..
-		cp -r root/llhzz/merge/. calculate/workspace/data/new_zz/mzvj/
+		cp -r root/channel_ll/merge/. calculate/workspace/data/new_zz/mzvj/
 		cd calculate/workspace/data/new_zz/mzvj/
 		root -l -q mzvj.cxx
            else
@@ -575,7 +575,7 @@ case $option in
 		hadd ./merge/mzjv_sm.root bkg_zz_sl0mu_up.root bkg_zz_sl0mu_down.root bkg_zz_sl0tau_up.root bkg_zz_sl0tau_down.root bkg_ww_sl0muq.root
 		
 		cd ../..
-		cp -r root/llhzz/merge/. calculate/workspace/data/new_zz/mzjv/
+		cp -r root/channel_ll/merge/. calculate/workspace/data/new_zz/mzjv/
 		cd calculate/workspace/data/new_zz/mzjv/
 		root -l -q mzjv.cxx
             fi
@@ -586,8 +586,12 @@ case $option in
            echo "If it is not, please do so \n" 
            echo "Ready to go next ? Please type ENTER or stop now (Ctrl-C)" 
            read flag
+
            cd ./calculate/workspace/
-           if [ ${channel_opt} = 1 ]; then
+	   mkdir -p ./bin
+	   mkdir -p ./lib
+	   make clean
+           if [ ${channel_opt_ll} = 1 ]; then
                cp -p ./inc/shapeFit_HZZ_vvjj.h ./inc/shapeFit.h
            else
                cp -p ./inc/shapeFit_HZZ_jjvv.h ./inc/shapeFit.h
@@ -632,7 +636,7 @@ case $option in
 
     2.1.4) echo "Generate Condor job scripts..."
            mkdir -p ./run/channel_nn/nnh2zz/condor/script/marlin
-           ./python/gen_condorscripts.py ${channel_opt_nn} 1 ./run/channel_nn/nnh2zz/steers ./run/channel_nn/nnh2zz/condor ${sel_signal}
+           ./python/gen_condorscripts.py ${channel_opt_nn} 1 ./run/channel_nn/nnh2zz/steers ./run/channel_nn/nnh2zz/condor ${sel_signal} ${nnhzz}
            ;;
 
     2.1.5) echo "Submit Condor jobs for pre-selection on signal..."
@@ -951,41 +955,44 @@ case $option in
            ;;
 
     2.4.4) echo  "Save results..."
-           rm -rf ./root/nnhzz
-           mkdir -p   ./root/nnhzz/merge
-           python ./python/save_root.py  ./table/bg_2f.txt  ./table/bg_4f.txt  ./table/zh_sample_list.txt ${nnhzz}
+           rm -rf ./root/channel_nn
+           mkdir -p   ./root/channel_nn/merge
+           python ./python/save_root.py  ${nnhzz} ./table/bg_2f.txt  ./table/bg_4f.txt  ./table/zh_sample_list.txt 
 
-           cd ./root/nnhzz
+           cd ./root/channel_nn
 
-           if [ ${channel_opt_nn} = 1 ]; then
-               cp sig.root ./merge/mzvj_sig.root
-               hadd ./merge/mzvj_zz.root bkg_e2e2h_zz.root bkg_e3e3h_zz.root bkg_nnh_zz.root
-               hadd ./merge/mzvj_ww.root bkg_e2e2h_ww.root bkg_e3e3h_ww.root
-               hadd ./merge/mzvj_tt.root bkg_e2e2h_e3e3.root bkg_e3e3h_e3e3.root
-               hadd ./merge/mzvj_az.root bkg_e2e2h_az.root bkg_e3e3h_az.root
-               hadd ./merge/mzvj_sm.root bkg_zz_l0taumu.root bkg_zz_l04tau.root bkg_zz_sl0tau_up.root
-
-               cd ../..
-               cp -r root/nnhzz/merge/. calculate/workspace/data/new_zz/mzvj/
-               cd calculate/workspace/data/new_zz/mzvj/
-               root -l -q mzvj.cxx
-           else
-               cp sig.root ./merge/mzjv_sig.root
-               hadd ./merge/mzjv_zz.root bkg_e2e2h_zz.root bkg_e3e3h_zz.root bkg_qqh_zz.root
-               hadd ./merge/mzjv_ww.root bkg_e2e2h_ww.root bkg_e3e3h_ww.root
-               hadd ./merge/mzjv_tt.root bkg_e2e2h_e3e3.root bkg_qqh_e3e3.root
-               hadd ./merge/mzjv_az.root bkg_e2e2h_az.root bkg_qqh_az.root
-               hadd ./merge/mzjv_bb.root bkg_e2e2h_bb.root
-               hadd ./merge/mzjv_cc.root bkg_e2e2h_cc.root
-               hadd ./merge/mzjv_gg.root bkg_e2e2h_gg.root
-               hadd ./merge/mzjv_sm.root bkg_zz_sl0mu_up.root bkg_zz_sl0mu_down.root bkg_zz_sl0tau_up.root bkg_zz_sl0tau_down.root bkg_ww_sl0muq.root
-
-               cd ../..
-               cp -r root/nnhzz/merge/. calculate/workspace/data/new_zz/mzjv/
-               cd calculate/workspace/data/new_zz/mzjv/
-               root -l -q mzjv.cxx
-           fi
-           .q
+# Comment [ 2019-10-28 ] :
+# Following section should be updated (based on 1.4.4)  so as to fit to the nnHZZ channel, thus, they all are commented out for the moment 
+# 
+#           if [ ${channel_opt_nn} = 1 ]; then
+#               cp sig.root ./merge/mzvj_sig.root
+#               hadd ./merge/mzvj_zz.root bkg_e2e2h_zz.root bkg_e3e3h_zz.root bkg_nnh_zz.root
+#               hadd ./merge/mzvj_ww.root bkg_e2e2h_ww.root bkg_e3e3h_ww.root
+#               hadd ./merge/mzvj_tt.root bkg_e2e2h_e3e3.root bkg_e3e3h_e3e3.root
+#               hadd ./merge/mzvj_az.root bkg_e2e2h_az.root bkg_e3e3h_az.root
+#               hadd ./merge/mzvj_sm.root bkg_zz_l0taumu.root bkg_zz_l04tau.root bkg_zz_sl0tau_up.root
+#
+#               cd ../..
+#               cp -r root/nnhzz/merge/. calculate/workspace/data/new_zz/mzvj/
+#               cd calculate/workspace/data/new_zz/mzvj/
+#               root -l -q mzvj.cxx
+#           else
+#               cp sig.root ./merge/mzjv_sig.root
+#               hadd ./merge/mzjv_zz.root bkg_e2e2h_zz.root bkg_e3e3h_zz.root bkg_qqh_zz.root
+#               hadd ./merge/mzjv_ww.root bkg_e2e2h_ww.root bkg_e3e3h_ww.root
+#               hadd ./merge/mzjv_tt.root bkg_e2e2h_e3e3.root bkg_qqh_e3e3.root
+#               hadd ./merge/mzjv_az.root bkg_e2e2h_az.root bkg_qqh_az.root
+#               hadd ./merge/mzjv_bb.root bkg_e2e2h_bb.root
+#               hadd ./merge/mzjv_cc.root bkg_e2e2h_cc.root
+#               hadd ./merge/mzjv_gg.root bkg_e2e2h_gg.root
+#               hadd ./merge/mzjv_sm.root bkg_zz_sl0mu_up.root bkg_zz_sl0mu_down.root bkg_zz_sl0tau_up.root bkg_zz_sl0tau_down.root bkg_ww_sl0muq.root
+#
+#               cd ../..
+#               cp -r root/nnhzz/merge/. calculate/workspace/data/new_zz/mzjv/
+#               cd calculate/workspace/data/new_zz/mzjv/
+#               root -l -q mzjv.cxx
+#           fi
+#           .q
            ;;
 
     2.4.5) echo  "fit results...\n" #source setupATLAS.sh first
@@ -993,17 +1000,21 @@ case $option in
            echo "If it is not, please do so \n" 
            echo "Ready to go next ? Please type ENTER or stop now (Ctrl-C)" 
            read flag
-           cd ./calculate/workspace/
-           if [ ${channel_opt} = 1 ]; then
-               cp -p ./inc/shapeFit_HZZ_vvjj.h ./inc/shapeFit.h
-           else
-               cp -p ./inc/shapeFit_HZZ_jjvv.h ./inc/shapeFit.h
-           fi
 
-           cd ./calculate/workspace/
-           ./job/run.sh
-           ./job/plot.sh
-           echo "Please check the output under ./calculate/workspace/out/ " 
+# Comment [ 2019-10-28 ] :
+# Following section should be updated (based on 1.4.5)  so as to fit to the nnHZZ channel, thus, they all are commented out for the moment 
+#
+#           cd ./calculate/workspace/
+#           if [ ${channel_opt} = 1 ]; then
+#               cp -p ./inc/shapeFit_HZZ_vvjj.h ./inc/shapeFit.h
+#           else
+#               cp -p ./inc/shapeFit_HZZ_jjvv.h ./inc/shapeFit.h
+#           fi
+#
+#           cd ./calculate/workspace/
+#           ./job/run.sh
+#           ./job/plot.sh
+#           echo "Please check the output under ./calculate/workspace/out/ " 
            ;;
     esac
 }


### PR DESCRIPTION
-- Slightly update lines including the fitting part for llhzz channel .

-- Since the procedure (2.4.4) should be modified according to the nnhzz data status,
( I personally think , even for that we could change the code structure from Kaili,
so that the changes to be made for each specific channel is much more reduced )
the latter half of (2.4.4) is commented out.

To be fair, Kaili does not need to arrange the code like that
since he needs to collect so many ntuples with different styles, that prevent to make 
the simple and easy structure.

-- Above is the same for (2.4,5). Even it might worse that it can over-wirte the results 
of llhzz. Therefore,  almost entire lines of 2.4.5 is  commented out to wait another PR for this part.
    
